### PR TITLE
Fix message order and prefix bug

### DIFF
--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -113,9 +113,9 @@ func RunChat(ctx context.Context,
 			pretty, _ := json.MarshalIndent(result, "", "  ")
 			fmt.Println("🤖 JSON:\n", string(pretty))
 
-			assistantMsg := types.Message{Role: types.RoleAssistant, Content: string(pretty)}
 			userMsg := types.Message{Role: types.RoleUser, Content: userInput}
-			history = append(history, assistantMsg, userMsg)
+			assistantMsg := types.Message{Role: types.RoleAssistant, Content: string(pretty)}
+			history = append(history, userMsg, assistantMsg)
 
 			if sessionID != "" {
 				_ = memory.Append(sessionID, []types.Message{userMsg, assistantMsg})
@@ -134,9 +134,9 @@ func RunChat(ctx context.Context,
 				continue
 			}
 			ans := buf.String()
-			assistantMsg := types.Message{Role: types.RoleAssistant, Content: ans}
 			userMsg := types.Message{Role: types.RoleUser, Content: userInput}
-			history = append(history, assistantMsg, userMsg)
+			assistantMsg := types.Message{Role: types.RoleAssistant, Content: ans}
+			history = append(history, userMsg, assistantMsg)
 
 			if sessionID != "" {
 				_ = memory.Append(sessionID, []types.Message{userMsg, assistantMsg})
@@ -148,9 +148,9 @@ func RunChat(ctx context.Context,
 				continue
 			}
 			fmt.Println("🤖:", ans)
-			assistantMsg := types.Message{Role: types.RoleAssistant, Content: ans}
 			userMsg := types.Message{Role: types.RoleUser, Content: userInput}
-			history = append(history, assistantMsg, userMsg)
+			assistantMsg := types.Message{Role: types.RoleAssistant, Content: ans}
+			history = append(history, userMsg, assistantMsg)
 
 			if sessionID != "" {
 				_ = memory.Append(sessionID, []types.Message{userMsg, assistantMsg})

--- a/internal/optimizer/store.go
+++ b/internal/optimizer/store.go
@@ -48,7 +48,7 @@ func (s *Store) List(template string) ([]Record, error) {
 			return nil
 		}
 		c := b.Cursor()
-		prefix := []byte(template + ":")
+		prefix := []byte(template + "/")
 		for k, v := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
 			var r Record
 			_ = json.Unmarshal(v, &r)


### PR DESCRIPTION
## Summary
- maintain correct user/assistant order in interactive chat history
- fix optimizer store listing prefix

## Testing
- `go test ./...` *(fails: github.com packages download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fbac7f044832cb4068414a4788c47