### PR TITLE
Improve documentation for memory and cache

### DIFF
--- a/person.schema.json
+++ b/person.schema.json
@@ -1,9 +1,9 @@
 {
-  "":"http://json-schema.org/draft-07/schema#",
-  "type":"object",
-  "required":["name","age"],
-  "properties":{
-    "name":{"type":"string"},
-    "age":{"type":"integer","minimum":0}
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["name", "age"],
+  "properties": {
+    "name": {"type": "string"},
+    "age": {"type": "integer", "minimum": 0}
   }
 }


### PR DESCRIPTION
## Summary
- fix sample JSON schema
- expand CLI usage documentation
- document conversation memory support and cache endpoints
- outline template management via CLI
- update project structure diagram
- simplify contribution instructions

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fc49a6758832cb35c5dad3bbaefde